### PR TITLE
Fix a couple syntax errors in answer 4.1

### DIFF
--- a/104-Kleisli-Categories.md
+++ b/104-Kleisli-Categories.md
@@ -40,7 +40,7 @@ template<class A, class B, class C>
     return [m1, m2](A x) {
         auto p1 = m1(x);
         if (!p1.isValid()) {
-            return <optional><C>{};
+            return optional<C>{};
         }
         auto p2 = m2(p1.value());
         return p2;
@@ -51,7 +51,7 @@ template<class A, class B, class C>
 Identity:
 
 ```cpp
-template<class A> optional<A> identity(A) {
+template<class A> optional<A> identity(A x) {
     return optional<A>{x};
 }
 ```


### PR DESCRIPTION
- `<optional>` should not be wrapped in brackets
- `x` should be defined

Tests: I made a small [playground at cpp.sh](https://cpp.sh/?source=%2F%2F+Example+program%0A%23include+%3Ciostream%3E%0A%23include+%3Cvector%3E%0A%0Astruct+A+%7B%0A++int+i%3B%0A%7D%3B%0A%0Avoid+foo(std%3A%3Afunction%3Cvoid(A)%3E+f)+%7B%0A++++f(A%7B42%7D)%3B%0A%7D%0A%0Aint+main()%0A%7B%0A++foo(%5B%5D(A+a)+%7B%7D)%3B%0A%7D).

---

By the way, thank you so much for publishing these! They are helping me verify (or refute) my understanding.  I didn't understand free categories until I checked your answers in a previous chapter.